### PR TITLE
docs: add JSDoc type annotations to all utility functions

### DIFF
--- a/src/createCoordsTransformer.js
+++ b/src/createCoordsTransformer.js
@@ -1,3 +1,16 @@
+/**
+ * Create a function that transforms mouse/pointer event coordinates
+ * into SVG coordinate space. Useful for interactive SVG applications.
+ *
+ * @param {SVGSVGElement} svg - The SVG element to transform coordinates for
+ * @returns {function(MouseEvent): {x: number, y: number}} Transform function that converts event coords to SVG coords
+ * @example
+ * const transform = createCoordsTransformer(svgElement)
+ * svg.addEventListener('mousemove', (e) => {
+ *   const { x, y } = transform(e)
+ *   // x, y are now in SVG coordinate space
+ * })
+ */
 function createCoordsTransformer(svg) {
   const pt = svg.createSVGPoint();
 

--- a/src/createNoiseGrid.js
+++ b/src/createNoiseGrid.js
@@ -1,5 +1,20 @@
 import SimplexNoise from "simplex-noise";
 
+/**
+ * @typedef {Object} NoiseCell
+ * @property {number} x - Cell x position
+ * @property {number} y - Cell y position
+ * @property {number} width - Cell width
+ * @property {number} height - Cell height
+ * @property {number} noiseValue - Simplex noise value (-1 to 1)
+ */
+
+/**
+ * @typedef {Object} NoiseGridResult
+ * @property {NoiseCell[]} cells - Array of noise cells
+ * @property {function({x: number, y: number}): NoiseCell} lookup - Get cell at a position
+ */
+
 const defaultOpts = {
   width: 200,
   height: 200,
@@ -22,6 +37,23 @@ function lookup(cells, width, height, cols, resolution) {
   };
 }
 
+/**
+ * Create a grid of simplex noise values, useful for flow fields and textures.
+ *
+ * @param {Object} [opts] - Configuration options
+ * @param {number} [opts.width=200] - Grid width in pixels
+ * @param {number} [opts.height=200] - Grid height in pixels
+ * @param {number} [opts.resolution=8] - Number of cells in each dimension
+ * @param {number} [opts.xInc=0.01] - Noise x increment (lower = smoother)
+ * @param {number} [opts.yInc=0.01] - Noise y increment (lower = smoother)
+ * @param {number} [opts.seed] - Random seed for reproducible noise
+ * @returns {NoiseGridResult} Grid with cells and lookup function
+ * @example
+ * const grid = createNoiseGrid({ width: 400, height: 400, resolution: 20 })
+ * // Get noise at any position
+ * const cell = grid.lookup({ x: 150, y: 200 })
+ * const angle = cell.noiseValue * Math.PI * 2 // Use for flow field
+ */
 function createNoiseGrid(opts) {
   opts = Object.assign({}, defaultOpts, opts);
 

--- a/src/createQtGrid.js
+++ b/src/createQtGrid.js
@@ -1,5 +1,24 @@
 import Quadtree from "@timohausmann/quadtree-js";
 
+/**
+ * @typedef {Object} QtGridArea
+ * @property {number} x - X position (with gap applied)
+ * @property {number} y - Y position (with gap applied)
+ * @property {number} width - Width (with gap applied)
+ * @property {number} height - Height (with gap applied)
+ * @property {{start: number, end: number}} col - Column range in grid units
+ * @property {{start: number, end: number}} row - Row range in grid units
+ */
+
+/**
+ * @typedef {Object} QtGridResult
+ * @property {number} width - Total grid width
+ * @property {number} height - Total grid height
+ * @property {number} cols - Number of columns at maximum subdivision
+ * @property {number} rows - Number of rows at maximum subdivision
+ * @property {QtGridArea[]} areas - Array of subdivided areas
+ */
+
 const defaultQtOpts = {
   width: 1024,
   height: 1024,
@@ -36,6 +55,27 @@ function getIndividualQtNodes(node) {
   return individualNodes;
 }
 
+/**
+ * Create an adaptive grid using quadtree subdivision based on point density.
+ * Areas with more points subdivide further, creating varied cell sizes.
+ *
+ * @param {Object} [opts] - Configuration options
+ * @param {number} [opts.width=1024] - Grid width
+ * @param {number} [opts.height=1024] - Grid height
+ * @param {Array<{x: number, y: number}>} [opts.points=[]] - Points that drive subdivision
+ * @param {number} [opts.gap=0] - Gap between cells
+ * @param {number} [opts.maxQtObjects=10] - Max points per cell before subdividing
+ * @param {number} [opts.maxQtLevels=4] - Maximum subdivision depth
+ * @returns {QtGridResult} Grid with subdivided areas
+ * @example
+ * const grid = createQtGrid({
+ *   width: 800,
+ *   height: 600,
+ *   points: [{x: 100, y: 100}, {x: 105, y: 105}],
+ *   maxQtLevels: 3
+ * })
+ * grid.areas.forEach(area => drawRect(area.x, area.y, area.width, area.height))
+ */
 function createQtGrid(opts) {
   opts = Object.assign({}, defaultQtOpts, opts);
 

--- a/src/createVoronoiDiagram.js
+++ b/src/createVoronoiDiagram.js
@@ -2,6 +2,20 @@ import { Delaunay } from "d3-delaunay";
 import { polygonCentroid } from "d3";
 import { distToSegment } from "./distToSegment";
 
+/**
+ * @typedef {Object} VoronoiCell
+ * @property {Array<[number, number]>} points - Polygon vertices as [x, y] pairs
+ * @property {number} innerCircleRadius - Radius of largest circle that fits inside the cell
+ * @property {{x: number, y: number}} centroid - Center of the cell
+ * @property {VoronoiCell[]} neighbors - Adjacent cells
+ */
+
+/**
+ * @typedef {Object} VoronoiResult
+ * @property {VoronoiCell[]} cells - Array of Voronoi cells
+ * @property {Array<{x: number, y: number}>} points - Relaxed seed points
+ */
+
 const defaultOpts = {
   width: 1024,
   height: 1024,
@@ -10,6 +24,28 @@ const defaultOpts = {
   relaxationFactor: 0.5,
 };
 
+/**
+ * Create a Voronoi tessellation with Lloyd's relaxation for more uniform cells.
+ *
+ * @param {Object} [opts] - Configuration options
+ * @param {number} [opts.width=1024] - Diagram width
+ * @param {number} [opts.height=1024] - Diagram height
+ * @param {Array<{x: number, y: number}>} [opts.points=[]] - Seed points for cells
+ * @param {number} [opts.relaxIterations=8] - Number of Lloyd relaxation iterations
+ * @param {number} [opts.relaxationFactor=0.5] - How far to move toward centroid each iteration (0-1)
+ * @returns {VoronoiResult} Voronoi diagram with cells and relaxed points
+ * @example
+ * const { cells, points } = createVoronoiDiagram({
+ *   width: 800,
+ *   height: 600,
+ *   points: [{x: 100, y: 100}, {x: 400, y: 300}],
+ *   relaxIterations: 10
+ * })
+ * cells.forEach(cell => {
+ *   drawPolygon(cell.points)
+ *   drawCircle(cell.centroid.x, cell.centroid.y, cell.innerCircleRadius)
+ * })
+ */
 function createVoronoiDiagram(opts) {
   opts = Object.assign({}, defaultOpts, opts);
 

--- a/src/distToSegment.js
+++ b/src/distToSegment.js
@@ -11,9 +11,15 @@ function dist2(v, w) {
   return sqr(v[0] - w[0]) + sqr(v[1] - w[1]);
 }
 
-// p - point
-// v - start point of segment
-// w - end point of segment
+/**
+ * Calculate the squared distance from a point to a line segment.
+ * Use this instead of distToSegment when comparing distances (avoids sqrt).
+ *
+ * @param {[number, number]} p - Point as [x, y]
+ * @param {[number, number]} v - Segment start point as [x, y]
+ * @param {[number, number]} w - Segment end point as [x, y]
+ * @returns {number} Squared distance from point to segment
+ */
 function distToSegmentSquared(p, v, w) {
   var l2 = dist2(v, w);
   if (l2 === 0) return dist2(p, v);
@@ -22,9 +28,16 @@ function distToSegmentSquared(p, v, w) {
   return dist2(p, [v[0] + t * (w[0] - v[0]), v[1] + t * (w[1] - v[1])]);
 }
 
-// p - point
-// v - start point of segment
-// w - end point of segment
+/**
+ * Calculate the shortest distance from a point to a line segment.
+ *
+ * @param {[number, number]} p - Point as [x, y]
+ * @param {[number, number]} v - Segment start point as [x, y]
+ * @param {[number, number]} w - Segment end point as [x, y]
+ * @returns {number} Distance from point to segment
+ * @example
+ * distToSegment([5, 5], [0, 0], [10, 0]) // Returns 5 (perpendicular distance)
+ */
 function distToSegment(p, v, w) {
   return Math.sqrt(distToSegmentSquared(p, v, w));
 }

--- a/src/map.js
+++ b/src/map.js
@@ -1,3 +1,16 @@
+/**
+ * Re-map a number from one range to another (like Processing's map function).
+ *
+ * @param {number} n - The value to map
+ * @param {number} start1 - Lower bound of the input range
+ * @param {number} end1 - Upper bound of the input range
+ * @param {number} start2 - Lower bound of the output range
+ * @param {number} end2 - Upper bound of the output range
+ * @returns {number} The mapped value in the output range
+ * @example
+ * map(50, 0, 100, 0, 1)  // Returns 0.5
+ * map(25, 0, 100, 0, 10) // Returns 2.5
+ */
 function map(n, start1, end1, start2, end2) {
   if (start1 === end1) {
     return start2;

--- a/src/pointsInPath.js
+++ b/src/pointsInPath.js
@@ -1,3 +1,13 @@
+/**
+ * Extract evenly-spaced points along an SVG path element.
+ *
+ * @param {SVGPathElement} path - An SVG path DOM element
+ * @param {number} [numPoints=10] - Number of points to extract
+ * @returns {Array<{x: number, y: number}>} Array of points along the path
+ * @example
+ * const pathEl = document.querySelector('path')
+ * const points = pointsInPath(pathEl, 20)
+ */
 function pointsInPath(path, numPoints = 10) {
   if (numPoints < 1) {
     return []

--- a/src/prng.js
+++ b/src/prng.js
@@ -1,7 +1,22 @@
 import seedrandom from "seedrandom";
 
+/**
+ * Pseudo-random number generator instance.
+ * Use seedPRNG() to seed it for reproducible results.
+ * @type {function(): number}
+ */
 let prng = seedrandom();
 
+/**
+ * Seed the pseudo-random number generator for reproducible randomness.
+ * All random functions in this library use this shared PRNG.
+ *
+ * @param {string|number} seed - The seed value
+ * @returns {void}
+ * @example
+ * seedPRNG('my-seed')
+ * random(0, 100) // Always returns the same sequence for 'my-seed'
+ */
 function seedPRNG(seed) {
   prng = seedrandom(seed);
 }

--- a/src/random.js
+++ b/src/random.js
@@ -1,5 +1,17 @@
 import { prng } from "./prng";
 
+/**
+ * Generate a random number within a range, or pick a random element from an array.
+ *
+ * @param {number|Array} minOrArray - Minimum value (inclusive), or an array to pick from
+ * @param {number} [max] - Maximum value (inclusive) when minOrArray is a number
+ * @param {boolean} [toInteger=false] - If true, returns an integer instead of float
+ * @returns {number|*} Random number in range, or random array element
+ * @example
+ * random(0, 10)        // Returns float between 0 and 10
+ * random(0, 10, true)  // Returns integer between 0 and 10
+ * random(['a', 'b'])   // Returns 'a' or 'b'
+ */
 function random(minOrArray, max, toInteger = false) {
   if (Array.isArray(minOrArray)) {
     return minOrArray[random(0, minOrArray.length - 1, true)];

--- a/src/randomBias.js
+++ b/src/randomBias.js
@@ -1,5 +1,17 @@
 import { random } from "./random.js";
 
+/**
+ * Generate a biased random number within a range.
+ * The result is weighted toward the bias value based on the influence.
+ *
+ * @param {number} min - Minimum value (inclusive)
+ * @param {number} max - Maximum value (inclusive)
+ * @param {number} bias - The value to bias toward
+ * @param {number} [influence=0.5] - How strongly to bias toward the bias value (0-1)
+ * @returns {number} A random number biased toward the bias value
+ * @example
+ * randomBias(0, 100, 80, 0.8) // Tends to return values closer to 80
+ */
 function randomBias(min, max, bias, influence = 0.5) {
   const base = random(min, max);
   const mix = random(0, 1) * influence;

--- a/src/randomSnap.js
+++ b/src/randomSnap.js
@@ -1,5 +1,15 @@
 import { random } from "./random.js";
 
+/**
+ * Generate a random number snapped to the nearest interval.
+ *
+ * @param {number} min - Minimum value (inclusive)
+ * @param {number} max - Maximum value (inclusive)
+ * @param {number} snapInc - The interval to snap to
+ * @returns {number} A random number snapped to the nearest increment
+ * @example
+ * randomSnap(0, 100, 10) // Returns 0, 10, 20, 30, ... 100
+ */
 function randomSnap(min, max, snapInc) {
   return Math.round(random(min, max) / snapInc) * snapInc;
 }

--- a/src/spline.js
+++ b/src/spline.js
@@ -1,3 +1,16 @@
+/**
+ * Generate a smooth Catmull-Rom spline curve as an SVG path string.
+ *
+ * @param {Array<{x: number, y: number}>} [points=[]] - Array of control points
+ * @param {number} [tension=0.5] - Curve tension (0 = sharp corners, 1 = smooth)
+ * @param {boolean} [close=false] - Whether to close the path
+ * @param {function} [cb] - Optional callback called with ('MOVE'|'LINE', [x, y]) for each path command
+ * @param {number} [segmentCount=20] - Number of line segments per curve section (higher = smoother)
+ * @returns {string} SVG path string (e.g., "M0,0L10,10L20,5...")
+ * @example
+ * const path = spline([{x: 0, y: 0}, {x: 50, y: 100}, {x: 100, y: 0}])
+ * // Use in SVG: <path d={path} />
+ */
 function spline(points = [], tension = 0.5, close = false, cb, segmentCount = 20) {
 
     let tensionInv  = tension * 0.5;


### PR DESCRIPTION
Add comprehensive JSDoc documentation with @param, @returns, @typedef,
and @example tags to provide TypeScript-like IDE support for developers.
This improves autocomplete, type checking, and inline documentation.